### PR TITLE
[UPDATE] Mark as compatible with TYPO3 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require": {
     "php": "^5.5.0 || ^7.0.0",
-    "typo3/cms-core": "^7.6.1 || >=8.0.0 <8.4.0"
+    "typo3/cms-core": "^7.6.1 || ^8.0"
   },
   "replace": {
     "in2code/fal_sftp": "self.version",
@@ -25,7 +25,8 @@
     "in2code/falsftp": "self.version",
     "typo3-ter/fal_sftp": "self.version",
     "typo3-ter/fal-sftp": "self.version",
-    "typo3-ter/falsftp": "self.version"
+    "typo3-ter/falsftp": "self.version",
+    "falsftp": "self.version"
   },
   "suggest": {
     "phpseclib/phpseclib": "You need either this package or the ssh2 extension for this driver to work",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -22,7 +22,7 @@ $EM_CONF[$_EXTKEY] = [
     'category' => 'be',
     'constraints' => [
         'depends' => [
-            'typo3' => '7.6.1-7.99.99',
+            'typo3' => '7.6.1-8.7.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
I use your extension within a TYPO3 8.7 project. All I had to do, was to change the dependencies to be able to install it.