### PR TITLE
V10 compat

### DIFF
--- a/Configuration/FlexForm/DriverConfiguration.xml
+++ b/Configuration/FlexForm/DriverConfiguration.xml
@@ -9,7 +9,7 @@
                 <el>
                     <caseSensitive>
                         <TCEforms>
-                            <label>LLL:EXT:filelist/Resources/Private/Language/locallang_mod_file_list.xlf:localDriverFlexform_caseSensitive</label>
+                            <label>LLL:EXT:core/Resources/Private/Language/locallang_mod_file.xlf:sys_file_storage.localDriverFlexform_caseSensitive</label>
                             <config>
                                 <type>check</type>
                                 <default>1</default>

--- a/Configuration/FlexForm/DriverConfiguration.xml
+++ b/Configuration/FlexForm/DriverConfiguration.xml
@@ -72,6 +72,7 @@
                             <onChange>reload</onChange>
                             <config>
                                 <type>select</type>
+                                <renderType>selectSingle</renderType>
                                 <items>
                                     <numIndex index="0">
                                         <numIndex index="0">Please choose ...</numIndex>
@@ -95,6 +96,7 @@
                             <label>LLL:EXT:falsftp/Resources/Private/Language/locallang.xlf:flexform.general.adapter</label>
                             <config>
                                 <type>select</type>
+                                <renderType>selectSingle</renderType>
                                 <itemsProcFunc>VerteXVaaR\FalSftp\Environment\Detector->getItemsForAdapterSelection</itemsProcFunc>
                                 <items>
                                     <numIndex index="0">
@@ -206,6 +208,7 @@
                             <label>LLL:EXT:falsftp/Resources/Private/Language/locallang.xlf:flexform.experts.foreignKeyFingerprintMethod</label>
                             <config>
                                 <type>select</type>
+                                <renderType></renderType>
                                 <items>
                                     <numIndex index="0">
                                         <numIndex index="0">LLL:EXT:falsftp/Resources/Private/Language/locallang.xlf:flexform.experts.foreignKeyFingerprintMethod.sha1</numIndex>

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require": {
     "php": "^5.5.0 || ^7.0.0",
-    "typo3/cms-core": "^7.6.1 || ^8.0 || ^9.0"
+    "typo3/cms-core": "^9.0 || ^10.0"
   },
   "replace": {
     "falsftp": "self.version",


### PR DESCRIPTION
First step for TYPO3 V10 compatibility

* works only with https://review.typo3.org/c/Packages/TYPO3.CMS/+/62087 applied

*ToDo*

* Implement new dependency injection: https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.0/Feature-84112-SymfonyDependencyInjectionForCoreAndExtbase.html The current implementation has issues with phpseclib and public / private key auth. Password - based login works.
* Test ext-ssh2